### PR TITLE
Fix for old/wrong values being returned when triggered by device orientation change

### DIFF
--- a/Viewport.m
+++ b/Viewport.m
@@ -39,8 +39,8 @@ RCT_EXPORT_MODULE();
     _lastKnownDimensions = RCTCurrentDimensions();
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(deviceOrientationDidChangeNotification:)
-                                                 name:UIDeviceOrientationDidChangeNotification
+                                             selector:@selector(statusBarOrientationDidChangeNotification:)
+                                                 name:UIApplicationDidChangeStatusBarOrientationNotification
                                                object:nil];
   }
   
@@ -54,7 +54,7 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Notification methods
 
-- (void)deviceOrientationDidChangeNotification:(NSNotification*)note
+- (void)statusBarOrientationDidChangeNotification:(NSNotification*)note
 {
   _lastKnownDimensions = RCTCurrentDimensions();
   [_bridge.eventDispatcher sendDeviceEventWithName:@"dimensionsDidChange" body:_lastKnownDimensions];


### PR DESCRIPTION
I discovered that in some cases, `UIDeviceOrientationDidChangeNotification` is being sent before the screen's `applicationFrame` is updated, causing bad (old) dimension values to be reported to event listeners.

By observing `UIApplicationDidChangeStatusBarOrientationNotification` instead, the values for `applicationFrame` appear to be more reliable in reflecting changes to the application's frame.
