### PR TITLE
react-native should not be a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,5 @@
     "url": "https://github.com/pjjanak/react-native-viewport.git"
   },
   "dependencies": {
-    "react-native": "^0.4.0"
   }
 }


### PR DESCRIPTION
I'm not sure how this works for you guys, but in my case, I end up with two copies of react-native, as I would expect.
